### PR TITLE
Bean command & Integrating usage of `HasOptions` interface.

### DIFF
--- a/src/main/java/io/fireship/Main.java
+++ b/src/main/java/io/fireship/Main.java
@@ -4,11 +4,9 @@ import io.fireship.commands.CommandEnum;
 import io.fireship.events.ReadyListener;
 import io.fireship.events.RoleSelect;
 import io.fireship.events.SlashCommand;
-import io.fireship.model.Option;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
@@ -83,11 +81,11 @@ public class Main {
             HELPBOT.logger.info(" - Registering " + commandData.getName());
             SlashCommandData command = Commands.slash(commandData.getName(), commandData.getDescription());
 
-            for (int i = 0; i < commandData.getOptions().size(); i++) {
-                Option option = commandData.getOptions().get(i);
+            commandData.getOptions().ifPresent(list -> list.forEach(option -> {
                 HELPBOT.logger.info(" - - Adding option " + option.getName());
-                command.addOption(OptionType.STRING, option.getName(), option.getDescription(), option.isRequired());
-            }
+                command.addOption(option.getType(), option.getName(), option.getDescription(), option.isRequired());
+            }));
+
             commands.addCommands(command);
         });
         commands.queue();

--- a/src/main/java/io/fireship/Main.java
+++ b/src/main/java/io/fireship/Main.java
@@ -86,6 +86,7 @@ public class Main {
                 command.addOption(option.getType(), option.getName(), option.getDescription(), option.isRequired());
             }));
 
+            //noinspection ResultOfMethodCallIgnored
             commands.addCommands(command);
         });
         commands.queue();

--- a/src/main/java/io/fireship/commands/CommandEnum.java
+++ b/src/main/java/io/fireship/commands/CommandEnum.java
@@ -21,7 +21,7 @@ public enum CommandEnum {
     private final boolean moderatorOnly;
     private final Command command;
 
-    CommandEnum(String name, String description, boolean moderatorOnly, Command command, Option... options) {
+    CommandEnum(String name, String description, boolean moderatorOnly, Command command) {
         this.name = name;
         this.description = description;
         this.moderatorOnly = moderatorOnly;

--- a/src/main/java/io/fireship/commands/CommandEnum.java
+++ b/src/main/java/io/fireship/commands/CommandEnum.java
@@ -2,26 +2,23 @@ package io.fireship.commands;
 
 import io.fireship.commands.impl.*;
 import io.fireship.model.Option;
-import net.dv8tion.jda.api.interactions.commands.OptionType;
 
 import java.util.List;
+import java.util.Optional;
 
 public enum CommandEnum {
-
     HELP("help", "Displays a message on how to use this bot.", false, new Help()),
     PROHELP("prohelp", "Shows users how to unlock Fireship pro perks in Discord", false, new ProHelp()),
     CODE("code", "Shows users how to share code using markdown", false, new Code()),
-    THANK("thank", "Thanks a user for helping", false, new Thank(),
-            new Option("user", "The user to thank", true, OptionType.STRING),
-            new Option("message", "The reason you are thanking the user", false, OptionType.STRING)
-    ),
+    THANK("thank", "Thanks a user for helping", false, new Thank()),
     SETUP_LANGUAGE_ROLES("setup-tool-roles", "Sets up the tool roles message", true, new SetupToolRoles()),
     BROWSER("browser", "Common browser issues", false, new Browser()),
     RESPONSE("response", "Fireship response", true, new Response()),
+    BEAN("bean", "Bean a user", true, new Bean()),
     PING("ping", "Returns round trip time", false, new Ping());
+
     private final String name, description;
     private final boolean moderatorOnly;
-    private final List<Option> options;
     private final Command command;
 
     CommandEnum(String name, String description, boolean moderatorOnly, Command command, Option... options) {
@@ -29,7 +26,6 @@ public enum CommandEnum {
         this.description = description;
         this.moderatorOnly = moderatorOnly;
         this.command = command;
-        this.options = List.of(options);
     }
 
     //misc getters/setters
@@ -45,9 +41,14 @@ public enum CommandEnum {
     public Command getCommand() {
         return this.command;
     }
-    public List<Option> getOptions() {
-        return this.options;
-    }
+    public Optional<List<Option>> getOptions() {
+        var command = getCommand();
 
+        if (command instanceof HasOptions) {
+            return Optional.of(((HasOptions) command).getOptions());
+        }
+
+        return Optional.empty();
+    }
 }
 

--- a/src/main/java/io/fireship/commands/impl/Bean.java
+++ b/src/main/java/io/fireship/commands/impl/Bean.java
@@ -1,0 +1,65 @@
+package io.fireship.commands.impl;
+
+import io.fireship.commands.Command;
+import io.fireship.commands.HasOptions;
+import io.fireship.model.Option;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public class Bean implements Command, HasOptions {
+    @Override
+    public void onCommand(SlashCommandInteractionEvent event) {
+        Member moderator = event.getMember();
+        Member beaned = Objects.requireNonNull(event.getOption("user")).getAsMember();
+        var reason = event.getOption("reason");
+
+        assert moderator != null;
+        assert beaned != null;
+
+        var description = new StringBuilder();
+
+        if (reason != null) {
+            description.append(String.format(
+                    "<:activity:1137406861855969310> **Reason:** %s\n",
+                    reason.getAsString()
+            ));
+        } else {
+            description.append("<:activity:1137406861855969310> **Reason:** No reason.\n");
+        }
+
+        description.append(String.format(
+                "<:trustedAdmin:1137406869535735850>️ **Moderator:** %s<:whitelistUser:1137406878033387610><:whitelistInvite:1137406875302891680><:whitelistChannel:1137406873868451901><:upvoter:1137406871435759736><:potentialDanger:1137406863349121036>",
+                moderator.getAsMention()
+        ));
+
+        MessageEmbed response = new EmbedBuilder()
+                .setColor(Role.DEFAULT_COLOR_RAW)
+                .setTitle("Bean Result:")
+                .setDescription(description)
+                .addField(
+                    "Beaned:",
+                    "<:space:1137406865299488798><:success:1137406866251591731> " + beaned.getEffectiveName() + " [`" + beaned.getId() + "`]",
+                    false
+                )
+                .build();
+
+        event.replyEmbeds(response).queue();
+    }
+
+    @Override
+    public List<Option> getOptions() {
+        return List.of(
+                new Option("user", "The user to bean", true, OptionType.USER),
+                new Option("reason", "The reason you are beaning this user for", false, OptionType.STRING)
+        );
+    }
+}

--- a/src/main/java/io/fireship/commands/impl/Bean.java
+++ b/src/main/java/io/fireship/commands/impl/Bean.java
@@ -8,9 +8,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/resources/example.app.properties
+++ b/src/main/resources/example.app.properties
@@ -1,1 +1,1 @@
-bot_token=someTokenHere
+token=someTokenHere


### PR DESCRIPTION
I made a bean (fake ban) command á la wick.

As for the refactoring I made it so that you can now define slash command options within the `Command` implementation itself, instead of having to *also* define them on the `CommandEnum`.