### PR TITLE
changed Ping CommandEnum to accurately reflect moderatorOnly status

### DIFF
--- a/src/main/java/io/fireship/commands/CommandEnum.java
+++ b/src/main/java/io/fireship/commands/CommandEnum.java
@@ -15,7 +15,7 @@ public enum CommandEnum {
     BROWSER("browser", "Common browser issues", false, new Browser()),
     RESPONSE("response", "Fireship response", true, new Response()),
     BEAN("bean", "Bean a user", true, new Bean()),
-    PING("ping", "Returns round trip time", true, new Ping());
+    PING("ping", "Returns round trip time", false, new Ping());
 
     private final String name, description;
     private final boolean moderatorOnly;


### PR DESCRIPTION
very important critical bugfix!!

the Ping command CommandEnum was misleading users into thinking that the Ping command was limited to moderator use only,
when it is able to be used by everyone. 

This drastic change to the codebase resolves that concern. 